### PR TITLE
Update tests to skip public notification on PR

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -131,7 +131,7 @@ jobs:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           status: success
       - name: Notify public commit
-        if: ${{ (github.head_ref || github.ref_name) == 'master' || (github.head_ref || github.ref_name) == 'main' }}
+        if: ${{ github.event_name != 'pull_request' && ((github.head_ref || github.ref_name) == 'master' || (github.head_ref || github.ref_name) == 'main') }}
         uses: Sniddl/discord-commits@1.7
         with:
           webhook: ${{ secrets.PUBLIC_DISCORD_WEBHOOK }}


### PR DESCRIPTION
It's skipped anyway but the script seems to error without the condition